### PR TITLE
Drop unennecessary assignments from usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,7 @@ class Accessory
 end
 
 # create a new accessory
-pendant = Accessory.new(
-  name  = "pendant",
-  owner = "Alice",
-)
+pendant = Accessory.new("pendant", "Alice")
 
 # it can access via `[]` method
 puts pendant[:name]


### PR DESCRIPTION
Keyword arguments work with `some_call(foo: "value", bar: 123)` and currently only for default arguments. This just creates a couple of unused local variables and works because the value of an assignment expression is its right hand side.
